### PR TITLE
修复在非项目目录启动脚本时的路径错误

### DIFF
--- a/updatestart.sh
+++ b/updatestart.sh
@@ -7,8 +7,11 @@
 answers_download_url="http://81.68.160.189:35247/download"
 answers_file_name="answer.json"
 
-current_path=$(pwd)
+current_path=$(cd `dirname $0`; pwd)
 screen_name="lgb"
+
+echo $(date)
+echo "running path: $current_path"
 
 # pull latest git code
 echo "pull latest git code..."
@@ -16,16 +19,16 @@ git pull
 
 # update answer.json
 echo "update answer.json..."
-curl -s "$answers_download_url" > "$current_path"/"$answers_file_name"
+curl -s "$answers_download_url" > "$current_path/$answers_file_name"
 
 # kill lgb proxy
 echo "kill lgb proxy..."
 screen -S "$screen_name" -X quit
 
 # copy answers.json to release
-cp "$current_path/$answers_file_name" "$current_path"'/release/'"$answers_file_name"
+cp "$current_path/$answers_file_name" "$current_path/release/$answers_file_name"
 
 # start lgb proxy
 screen -dmS "$screen_name"
-screen -x -S "$screen_name" -p 0 -X stuff "chmod +x "$current_path"/release/HttpMonitor_linux && "$current_path"/release/HttpMonitor_linux"'\n'
+screen -x -S "$screen_name" -p 0 -X stuff "chmod +x $current_path/release/HttpMonitor_linux && $current_path/release/HttpMonitor_linux \n"
 echo "lgb proxy started"


### PR DESCRIPTION
## 问题修复

- 修复在非项目目录启动脚本时的路径错误，主要解决由crontab自启动时的路径错误问题
- 规范字符拼接

## 提供两个可用的cron脚本

> 首先假设项目被克隆在目录$HOME下

- 日志存储版

```
0 0 * * * /bin/sh $HOME/liangongbao-dati/updatestart.sh >> $HOME/lgb.log
```

- 不存储日志版

```
0 0 * * * /bin/sh $HOME/liangongbao-dati/updatestart.sh
```