### PR TITLE
自动添加可执行标识

### DIFF
--- a/updatestart.sh
+++ b/updatestart.sh
@@ -18,6 +18,11 @@ echo "pull latest git code..."
 git reset --hard
 git pull
 
+# make updatestart.sh and release/HttpMonitor executable
+echo "make updatestart.sh and release/HttpMonitor executable..."
+chmod +x $current_path/updatestart.sh
+chmod +x $current_path/release/HttpMonitor_linux
+
 # update answer.json
 echo "update answer.json..."
 curl -s "$answers_download_url" > "$current_path/$answers_file_name"


### PR DESCRIPTION
脚本本身和HttpMonitor_linux文件在拉取后自动添加executable文件标识，虽然不添加的话用sh命令运行脚本也没问题，但是可能在某些Linux机器上会执行失败，所以还是加上了（