### PR TITLE
弃用以前的answer.json更新地址

### DIFF
--- a/updatestart.sh
+++ b/updatestart.sh
@@ -4,7 +4,7 @@
 # crontab -e
 # 每天0点执行updatestart.sh：`0 0 * * * /bin/sh /path/to/updatestart.sh`
 
-answers_download_url="http://81.68.160.189:35247/download"
+# answers_download_url="http://81.68.160.189:35247/download"
 answers_file_name="answer.json"
 
 current_path=$(cd `dirname $0`; pwd)
@@ -24,15 +24,15 @@ chmod +x $current_path/updatestart.sh
 chmod +x $current_path/release/HttpMonitor_linux
 
 # update answer.json
-echo "update answer.json..."
-curl -s "$answers_download_url" > "$current_path/$answers_file_name"
+# echo "update answer.json..."
+# curl -s "$answers_download_url" > "$current_path/$answers_file_name"
 
 # kill lgb proxy
 echo "kill lgb proxy..."
 screen -S "$screen_name" -X quit
 
 # copy answers.json to release
-cp "$current_path/$answers_file_name" "$current_path/release/$answers_file_name"
+# cp "$current_path/$answers_file_name" "$current_path/release/$answers_file_name"
 
 # start lgb proxy
 screen -dmS "$screen_name"


### PR DESCRIPTION
自动更新时弃用以前的answer.json更新地址，仅拉取git题库